### PR TITLE
Add *.DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .ipynb_checkpoints/*
 data/*
 venv*
+
+# Mac OS
+*.DS_Store


### PR DESCRIPTION
Просто на macОС има един досаден .DS_Store файл във всяка папка, който е хубаво да се игнорира винаги